### PR TITLE
Fix tutorial missions in wrong order

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
+++ b/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
@@ -430,7 +430,7 @@ if (_canTute) then {
 						"Legal money? Where's the fun in that. I guess you could try selling to stores or leasing houses.",
 						"Thanks."
 					],
-					(OT_tutorialMissions select 1)
+					(OT_tutorialMissions select 2)
 				] call OT_fnc_doConversation;
 			}
 		];

--- a/addons/overthrow_main/functions/events/fn_keyHandler.sqf
+++ b/addons/overthrow_main/functions/events/fn_keyHandler.sqf
@@ -134,7 +134,7 @@ if(!dialog) then {
 											];
 											[{
 												playSound "3DEN_notificationDefault";
-												[] call (OT_tutorialMissions select 1);
+												// No mission here
 												hint "You have completed the tutorial. Good luck on your future journey!";
 												player setVariable ["OT_tute_inProgress", false];
 											},1,10] call CBA_fnc_waitAndExecute;
@@ -168,7 +168,7 @@ if(!dialog) then {
 											];
 											[{
 												playSound "3DEN_notificationDefault";
-												[] call (OT_tutorialMissions select 2);
+												[] call (OT_tutorialMissions select 1);
 												hint "You have completed the tutorial. Good luck on your future journey!";
 												player setVariable ["OT_tute_inProgress", false];
 											},2,10] call CBA_fnc_waitAndExecute;
@@ -196,7 +196,7 @@ if(!dialog) then {
 											];
 											[{
 												playSound "3DEN_notificationDefault";
-												[] call (OT_tutorialMissions select 3);
+												[] call (OT_tutorialMissions select 2);
 												hint "You have completed the tutorial. Good luck on your future journey!";
 												player setVariable ["OT_tute_inProgress", false];
 											},3,10] call CBA_fnc_waitAndExecute;

--- a/addons/overthrow_main/functions/events/fn_keyHandler.sqf
+++ b/addons/overthrow_main/functions/events/fn_keyHandler.sqf
@@ -134,7 +134,8 @@ if(!dialog) then {
 											];
 											[{
 												playSound "3DEN_notificationDefault";
-												// No mission here
+												// No mission here, so just clear the gun dealer waypoint.
+												call OT_fnc_clearPlayerWaypoint;
 												hint "You have completed the tutorial. Good luck on your future journey!";
 												player setVariable ["OT_tute_inProgress", false];
 											},1,10] call CBA_fnc_waitAndExecute;

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -47,10 +47,10 @@ OT_localMissions = [];
 }foreach("true" configClasses ( configFile >> "CfgOverthrowMissions" ));
 
 OT_tutorialMissions = [];
-OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_NATO.sqf", true]);
+OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_NATO.sqf", true]); // index 0
 //OT_tutorialMissions pushback (compileFinal preprocessFileLineNumbers "\overthrow_main\missions\tutorial\tut_CRIM.sqf");
-OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_Drugs.sqf", true]);
-OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_Economy.sqf", true]);
+OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_Drugs.sqf", true]); // index 1
+OT_tutorialMissions pushback (compileScript ["\overthrow_main\missions\tutorial\tut_Economy.sqf", true]); // index 2
 
 OT_NATO_HQ_garrisonPos = [];
 OT_NATO_HQ_garrisonDir = 0;

--- a/addons/overthrow_main/missions/tutorial/tut_CRIM.sqf
+++ b/addons/overthrow_main/missions/tutorial/tut_CRIM.sqf
@@ -1,3 +1,5 @@
+// THIS MISSION IS NOT ACTUALLY USED
+
 //Let's find some bandits to shoot
 
 private _done = player getVariable ["OT_tutesDone",[]];

--- a/addons/overthrow_main/missions/tutorial/tut_Drugs.sqf
+++ b/addons/overthrow_main/missions/tutorial/tut_Drugs.sqf
@@ -37,7 +37,7 @@ if(count _targets isEqualTo 0) exitWith {
                 //If the player fast travelled, give time to spawn
                 [{
                     //loop and hope we find a target
-                    [] call (OT_tutorialMissions select 2);
+                    [] call (OT_tutorialMissions select 1);
                 },0,10] call CBA_fnc_waitAndExecute;
             },
             _destination

--- a/addons/overthrow_main/missions/tutorial/tut_Economy.sqf
+++ b/addons/overthrow_main/missions/tutorial/tut_Economy.sqf
@@ -38,7 +38,7 @@ private _actualMission = {
                     //If the player fast travelled, give time to spawn
                     [{
                         //loop and hope we find a target
-                        [] call (OT_tutorialMissions select 3);
+                        [] call (OT_tutorialMissions select 2);
                     },0,10] call CBA_fnc_waitAndExecute;
                 },
                 _destination


### PR DESCRIPTION
**Before:**
In the tutorial when you go to the gun dealer and tell him that you want to make money illegally, he gives you a waypoint to the nearest wreck to salvage. If you say that you have had enough of criminals, he points you to a ganja buyer. If you later come to him again and ask to earn some legal money, he again points you to a ganja buyer.

**After:**
Every choice leads to the expected mission.

**What was broken:**
The tutorial actions pointed to the wrong mission scripts.