### PR TITLE
Add parameter to randomize loadouts

### DIFF
--- a/addons/overthrow_main/functions/AI/NPC/fn_initGendarm.sqf
+++ b/addons/overthrow_main/functions/AI/NPC/fn_initGendarm.sqf
@@ -17,7 +17,7 @@ _unit addEventHandler ["HandleDamage", {
 	};
 }];
 
-if((random 100) < 75) then {
+if((random 100) < 75 && ot_randomizeloadouts) then {
 	_unit setUnitLoadout [_unit call OT_fnc_getRandomLoadout, true];
 };
 

--- a/addons/overthrow_main/functions/AI/NPC/fn_initMilitary.sqf
+++ b/addons/overthrow_main/functions/AI/NPC/fn_initMilitary.sqf
@@ -1,6 +1,6 @@
 params ["_unit"];
 
-if((random 100) < 75) then {
+if((random 100) < 75 && ot_randomizeloadouts) then {
 	_unit setUnitLoadout [_unit call OT_fnc_getRandomLoadout, true];
 };
 

--- a/addons/overthrow_main/functions/AI/fn_randomizeLoadout.sqf
+++ b/addons/overthrow_main/functions/AI/fn_randomizeLoadout.sqf
@@ -74,7 +74,7 @@ if(_hasPrimary) then {
     };
 
     // Remove all incompatible attachments.
-    private _compatItems = _wpn call BIS_fnc_compatibleItems;
+    private _compatItems = compatibleItems _wpn;
     {
         if !(_x in _compatItems) then {(_newloadout # 0) set [_forEachIndex + 1, ""]};
     } forEach [((_newloadout # 0) # 1), ((_newloadout # 0) # 2), ((_newloadout # 0) # 3)];

--- a/addons/overthrow_main/mission_component.hpp
+++ b/addons/overthrow_main/mission_component.hpp
@@ -79,6 +79,12 @@ class Params {
 		texts[] = {"Yes", "No"};
 		default = 1;
 	};
+	class ot_randomizeloadouts {
+		title = "Randomize NATO loadouts";
+		values[] = {1,0};
+		texts[] = {"Yes", "No"};
+		default = 0;
+	};
 	class ace_medical_level {
         title = "ACE Medical Level";
         ACE_setting = 1;


### PR DESCRIPTION
Added: Mission parameter to determine whether BLUFOR loadouts are randomized or not (criminals remain unchanged), defaults to off
Changed: Loadout randomization optimized with compatibleItems command