### PR TITLE
Fix sqf syntax error in VCOM code

### DIFF
--- a/addons/overthrow_main/functions/AI/VCOM/Functions/VCM_Functions/Playground.sqf
+++ b/addons/overthrow_main/functions/AI/VCOM/Functions/VCM_Functions/Playground.sqf
@@ -8,7 +8,7 @@
 	_params set [0, -1];
 	_pos = _pos isFlatEmpty _params;
 	if (_pos isEqualTo []) exitWith {_pos};
-	_pos
+	_pos;
 
 
 


### PR DESCRIPTION
This missing semicolon caused a syntax error when compiling with ArmaScriptCompiler.