### PR TITLE
Fix nato reinforcements not spawning in small spaces

### DIFF
--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAPCInsertion.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAPCInsertion.sqf
@@ -2,11 +2,9 @@ params ["_frompos","_ao","_attackpos",["_delay",0]];
 if (_delay > 0) then {sleep _delay};
 private _vehtype = selectRandom OT_NATO_Vehicles_APC;
 private _squadtype = selectRandom OT_NATO_GroundForces;
-private _spawnpos = _frompos findEmptyPosition [15,100,_vehtype];
-if(count _spawnpos == 0) then {
-	_spawnpos = [_frompos,[5,25]] call SHK_pos_fnc_pos;
-};
-private _group1 = [_spawnpos, WEST, (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Infantry" >> _squadtype)] call BIS_fnc_spawnGroup;
+
+// Spawn a group to be seated in a transport vehicle
+private _group1 = [_frompos, WEST, (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Infantry" >> _squadtype)] call BIS_fnc_spawnGroup;
 _group1 deleteGroupWhenEmpty true;
 private _group2 = "";
 private _tgroup = false;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundReinforcements.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundReinforcements.sqf
@@ -9,9 +9,9 @@ private _spawnpos = _frompos;
 private _group1 = createGroup west;
 _group1 deleteGroupWhenEmpty true;
 
+// Spawn 4 soldiers to be seated in a transport vehicle
 for "_i" from 1 to 4 do {
-	private _p = _frompos findEmptyPosition [15,100,_vehtype];
-	(selectRandom OT_NATO_Units_LevelOne) createUnit [_p,_group1,"",0.3,"private"];//fix for units not spawning
+	(selectRandom OT_NATO_Units_LevelOne) createUnit [_frompos,_group1,"",0.3,"private"];
 };
 
 sleep 0.5;


### PR DESCRIPTION
Now NATO soldiers will spawn to reinforcement vehicles even if the vehicle is spawned into a small space. An example of this is Swarog base in Livonia.

Closes #33