### PR TITLE
Fix surplus shop inventory

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
+++ b/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
@@ -263,12 +263,6 @@ if (_canBuy) then {
 					};
 				}foreach(OT_items);
 
-				if(_cat isEqualTo "Surplus") then {
-					{
-						_s pushback [_x,-1];
-					}foreach(OT_allBackpacks);
-				};
-
 				[_town,_standing,_s] call OT_fnc_buyDialog;
 			};
 		}

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -181,7 +181,7 @@ OT_itemCategoryDefinitions = [
     ["Pharmacy",["Dressing","Bandage","morphine","adenosine","atropine","ACE_EarPlugs","epinephrine","bodyBag","quikclot","salineIV","bloodIV","plasmaIV","personalAidKit","surgicalKit","tourniquet","splint"]],
     ["Electronics",["Rangefinder","Cellphone","Radio","Watch","GPS","monitor","DAGR","_dagr","Battery","ATragMX","ACE_Flashlight","I_UavTerminal","ACE_Kestrel4500"]],
     ["Hardware",["Tool","CableTie","ACE_Spraypaint","wirecutter","ACE_rope3","ACE_rope6","ACE_rope12","ACE_rope15","ACE_rope18","ACE_rope27","ACE_rope36"]],
-    ["Surplus",["Rangefinder","Binocular","Compass","RangeCard","RangeTable","DefusalKit","SpottingScope","ACE_Vector","ACE_Yardage","ACE_Kestrel4500"]]
+    ["Surplus",["Rangefinder","Binocular","Compass","RangeCard","RangeTable","DefusalKit","SpottingScope","ACE_Vector","ACE_Yardage","ACE_Kestrel4500","ACE_NVG_Gen4","ACE_NVG_Wide"]]
 ];
 
 OT_items = [];
@@ -204,8 +204,6 @@ OT_staticBackpacks = [
 ];
 
 OT_backpacks = [
-	['ACE_NVG_Gen4',[10000,0,0,200]],
-	['ACE_NVG_Wide',[10000,0,0,400]],
 	["B_AssaultPack_cbr",20,0,0,1],
 	["B_AssaultPack_blk",20,0,0,1],
 	["B_AssaultPack_khk",20,0,0,1],

--- a/addons/overthrow_main/functions/integration/fn_detectItems.sqf
+++ b/addons/overthrow_main/functions/integration/fn_detectItems.sqf
@@ -147,11 +147,13 @@ private _getprice = {
     {
         _parents = ([_x,true] call BIS_fnc_returnParents);
         'Bag_Base' in _parents &&
-        !('Weapon_Bag_Base' in _parents) &&
-        (count (_x >> 'TransportItems') isEqualTo 0) &&
-        (count (_x >> 'MagazineItems') isEqualTo 0)
+        {getText (_x >> 'Faction') isEqualTo 'Default'} &&
+        {!('Weapon_Bag_Base' in _parents)} &&
+        {count (_x >> 'TransportItems') isEqualTo 0} &&
+        {count (_x >> 'TransportMagazines') isEqualTo 0} &&
+        {count (_x >> 'TransportWeapons') isEqualTo 0}
     }
-" configClasses ( configFile >> "CfgVehicles" ));
+" configClasses ( configFile >> "CfgVehicles" )); // Bags that do not have a faction (weapon and tripod bags do), and carry no content.
 //add craftable magazines
 {
     private _cls = configName _x;

--- a/addons/overthrow_main/functions/integration/fn_detectItems.sqf
+++ b/addons/overthrow_main/functions/integration/fn_detectItems.sqf
@@ -138,6 +138,10 @@ private _getprice = {
 {
     private _cls = configName _x;
     [_cls,"Surplus"] call _categorize;
+    if (isServer && {isNil {cost getVariable _cls}}) then {
+        private _mass = getNumber (_x >> "mass");
+        cost setVariable [_cls,[_mass,0,0,1],true]; // the price of a bag is its mass, unless otherwise stated in prices.sqf.
+    };
 }foreach("
     (getNumber (_x >> 'scope') isEqualTo 2) &&
     {


### PR DESCRIPTION
This PR resolves the chaos that is loose in the inventories of surplus shops.

**Bugs fixed:**
- Duplicate backpacks in surplus shops.
- Weapon tripods were sold in surplus shops.
- Backpacks with items (possibly weapons) inside were sold in surplus shops.
- Sometimes the mod tried to add NVGs as backpack for criminals.

**New features:**
- Backpacks now have sensible prices in surplus shops.
  - Previously almost all of them had undefined prices (so around $25 default price).
  - Now their prices are calculated based on mass, where base price = mass. This leads to quite sensible prices, for example "Assault Pack" is being sold at $40 and "Bergen Backpack" at $200.
  - These prices can be overridden by setting them in prices.sqf.

**New bugs:**
- ACE NVGs are not being sold in surplus shops. This is because the shop item discovery logic is generally broken and requires a lot of manual cranking to get any item there. This will be fixed in PR #43.