### PR TITLE
Improve shop item discovery

### DIFF
--- a/addons/overthrow_main/data/prices.sqf
+++ b/addons/overthrow_main/data/prices.sqf
@@ -74,7 +74,11 @@ OT_priceData = [
 ['Ace_splint',[10,0.1,0.1]],
 ['MineDetector',[100,0,0.5,0.5]],
 ['ACE_NVG_Gen4',[10000,0,0,200]],
+['ACE_NVG_Gen4_Green',[10000,0,0,200]],
+['ACE_NVG_Gen4_Black',[10000,0,0,200]],
 ['ACE_NVG_Wide',[10000,0,0,400]],
+['ACE_NVG_Wide_Green',[10000,0,0,400]],
+['ACE_NVG_Wide_Black',[10000,0,0,400]],
 //Weapons
 ['SMG_01_F',[250,0,0.5,0]],
 ['SMG_02_F',[250,0,0.5,0]],

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -686,15 +686,15 @@ OT_allBLURifleMagazines = [];
 			} else {
 				OT_allCheapRifles pushback _name;
 			};
-			[_cost]
+			[_cost, 2]
 		};
 		if (_weaponType ==  "MachineGun") exitWith {
 			OT_allMachineGuns pushBack _name;
-			[1500];
+			[1500, 2];
 		};
 		if (_weaponType ==  "SniperRifle") exitWith {
 			OT_allSniperRifles pushBack _name;
-			[4000];
+			[4000, 2];
 		};
 		if (_weaponType ==  "Handgun") exitWith {
 			private _cost = _caliber call {
@@ -709,7 +709,7 @@ OT_allBLURifleMagazines = [];
 		};
 		if (_weaponType ==  "MissileLauncher") exitWith {
 			OT_allMissileLaunchers pushBack _name;
-			[15000];
+			[15000, 2];
 		};
 		if (_weaponType ==  "RocketLauncher") exitWith {
 			OT_allRocketLaunchers pushBack _name;
@@ -717,7 +717,7 @@ OT_allBLURifleMagazines = [];
 			if(_name == "launch_NLAW_F") then {
 				_cost=1000
 			};
-			[_cost]
+			[_cost, 2]
 		};
 		if (_weaponType ==  "Vest") exitWith {
 			if !(_name in ["V_RebreatherB","V_RebreatherIA","V_RebreatherIR","V_Rangemaster_belt"]) then {
@@ -734,14 +734,15 @@ OT_allBLURifleMagazines = [];
 						OT_allCheapVests pushback _name;
 					};
 				};
-				[_cost]
+				[_cost, 2]
 			} else {
 				[]
 			};
 		};
+		// There are many other items in _allWeapons, set their prices elsewhere.
 		[]
-	}) params [["_cost", 500], ["_steel", 2]];
-	if(isServer && isNil {cost getVariable _name}) then {
+	}) params ["_cost", "_steel"];
+	if(isServer && {isNil {cost getVariable _name}} && {! isNil {_cost}}) then {
 		cost setVariable [_name,[_cost,0,_steel,0],true];
 	};
 } foreach (_allWeapons);

--- a/addons/overthrow_main/functions/integration/fn_detectItems.sqf
+++ b/addons/overthrow_main/functions/integration/fn_detectItems.sqf
@@ -94,44 +94,20 @@ private _getprice = {
                 if(_category != "General") then {
                     _primaryCategory = _category;
                 };
-                {
-                    private _c = configName _x;
-                    [_c,_category] call _categorize;
-
-                    private _craftable = getNumber ( _x >> "ot_craftable" );
-
-                    if(_craftable > 0) then {
-                        private _recipe = call compileFinal getText (_x >> "ot_craftRecipe");
-                        private _qty = getNumber ( _x >> "ot_craftQuantity" );
-                        OT_craftableItems pushback [configName _x,_recipe,_qty];
-                    };
-
-                    if(isServer && isNil {cost getVariable _c}) then {
-                        cost setVariable [_c,[_x,_primaryCategory] call _getprice,true];
-                    };
-                }foreach(format ["inheritsFrom _x isEqualTo (configFile >> ""CfgWeapons"" >> ""%1"")",_cls] configClasses ( configFile >> "CfgWeapons" ));
             };
         }foreach(_types);
     }foreach(OT_itemCategoryDefinitions);
 
-    if(isServer && isNil {cost getVariable _c}) then {
-        cost setVariable [_cls,[_x,_primaryCategory] call _getprice,true];
-    };
-
     if(_categorized) then {
+        if(isServer && isNil {cost getVariable _cls}) then {
+            cost setVariable [_cls,[_x,_primaryCategory] call _getprice,true];
+        };
+
         OT_allItems pushback _cls;
     };
 }foreach("
     (getNumber (_x >> 'scope') isEqualTo 2) &&
-    {
-        inheritsFrom _x in [
-            configFile >> 'CfgWeapons' >> 'Binocular',
-            configFile >> 'CfgWeapons' >> 'ItemCore',
-            configFile >> 'CfgWeapons' >> 'ACE_ItemCore',
-            configFile >> 'CfgWeapons' >> 'ACE_ropeBase',
-            configFile >> 'CfgWeapons' >> 'UavTerminal_base'
-        ]
-    }
+    {(configName _x call BIS_fnc_itemType) # 0 isEqualTo 'Item'}
 " configClasses ( configFile >> "CfgWeapons" ));
 
 //add Bags


### PR DESCRIPTION
**Before:**
When searching for items to sell in a shop, only direct children of certain 5 classes and their children (2 levels deep) were searched. This made adding new items to shops hard and there were already some items that should be there but weren't.

Also uniforms, helmets, weapon attachments and detonators were priced using the weapon pricing logic.

**After:**
Now all items are searched. Items are defined as those where `BIS_fnc_itemType` returns `Item`. In vanilla Arma 3 the only difference is that binoculars (and NVGs after PR #42) may now be found in shop inventories. With mods such as RHS however, this may have a huge effect on shop inventory.

Uniforms, helmets, weapon attachments and detonators are now priced correctly using their own pricing logics.