### PR TITLE
Fix cleanup of old units

### DIFF
--- a/addons/overthrow_main/functions/AI/orders/fn_orderLoot.sqf
+++ b/addons/overthrow_main/functions/AI/orders/fn_orderLoot.sqf
@@ -106,11 +106,8 @@ private _target = _sorted select 0;
 
 			[_deadguy,_unit] call OT_fnc_takeStuff;
 			sleep 2;
-			if (isNull objectParent _deadguy) then {
-				deleteVehicle _deadguy;
-			} else {
-				[(objectParent _deadguy), _deadguy] remoteExec ["deleteVehicleCrew", _deadguy, false];
-			};
+			moveOut _deadguy;
+			deleteVehicle _deadguy;
 			_timeout = time + 30;
 			_unit doMove ASLtoAGL (getPosASL _t);
 			waitUntil {sleep 1; (!alive _unit) || (isNull _t) || (_unit distance _t < 12) || (_timeOut < time)};

--- a/addons/overthrow_main/functions/UI/dialogs/fn_manageRecruitsDialog.sqf
+++ b/addons/overthrow_main/functions/UI/dialogs/fn_manageRecruitsDialog.sqf
@@ -35,11 +35,8 @@ recruitSelected = {
 
 dismissRecruit = {
 	_recruit = (units group player) select (lbValue[1500,lbCurSel 1500]-1);
-	if (isNull objectParent _recruit) then {
-		deleteVehicle _recruit;
-	} else {
-		[(objectParent _recruit), _recruit] remoteExec ["deleteVehicleCrew", _recruit, false];
-	};
+	moveOut _recruit;
+	deleteVehicle _recruit;
 	ctrlEnable [1600,false];
 	[] call refreshRecruits;
 	disableSerialization;

--- a/addons/overthrow_main/functions/UI/display/fn_refreshEmployees.sqf
+++ b/addons/overthrow_main/functions/UI/display/fn_refreshEmployees.sqf
@@ -2,10 +2,7 @@ private _data = _this call OT_fnc_getBusinessData;
 private _pos = _data select 0;
 private _group = spawner getVariable [format["employees%1",_this],grpNull];
 {
-    if (isNull objectParent _x) then {
-		deleteVehicle _x;
-	} else {
-		[(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-	};
+    moveOut _x;
+    deleteVehicle _x;
 }foreach(units _group);
 deleteGroup _group;

--- a/addons/overthrow_main/functions/actions/fn_editLoadout.sqf
+++ b/addons/overthrow_main/functions/actions/fn_editLoadout.sqf
@@ -92,11 +92,8 @@ if ((_civ getVariable ["cba_projectile_firedEhId", -1]) != -1) then {
     playSound "3DEN_notificationDefault";
     "Saved loadout" call OT_fnc_notifyMinor;
 
-    if (isNull objectParent _unit) then {
-		deleteVehicle _unit;
-	} else {
-		[(objectParent _unit), _unit] remoteExec ["deleteVehicleCrew", _unit, false];
-	};
+    moveOut _unit;
+    deleteVehicle _unit;
 
     [_thisType, _thisId] call CBA_fnc_removeEventHandler;
 },[_civ,_cls]] call CBA_fnc_addEventHandlerArgs;

--- a/addons/overthrow_main/functions/actions/fn_editPoliceLoadout.sqf
+++ b/addons/overthrow_main/functions/actions/fn_editPoliceLoadout.sqf
@@ -86,11 +86,8 @@ if ((_civ getVariable ["cba_projectile_firedEhId", -1]) != -1) then {
 
     playSound "3DEN_notificationDefault";
     "Saved police loadout" call OT_fnc_notifyMinor;
-    if (isNull objectParent _unit) then {
-		deleteVehicle _unit;
-	} else {
-		[(objectParent _unit), _unit] remoteExec ["deleteVehicleCrew", _unit, false];
-	};
+    moveOut _unit;
+    deleteVehicle _unit;
 
     [_thisType, _thisId] call CBA_fnc_removeEventHandler;
 },[_civ]] call CBA_fnc_addEventHandlerArgs;

--- a/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
+++ b/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
@@ -544,7 +544,8 @@ if (_canBuyBoats) then {
 							waitUntil {_veh distance _pos < 100 || time > _timeout};
 							if(!alive _driver) exitWith{};
 
-							[(objectParent _driver), _driver] remoteExec ["deleteVehicleCrew", _driver, false];
+							moveOut _driver;
+							deleteVehicle _driver;
 							deleteVehicle _veh;
 						};
 					};

--- a/addons/overthrow_main/functions/cleanup/fn_cleanDead.sqf
+++ b/addons/overthrow_main/functions/cleanup/fn_cleanDead.sqf
@@ -2,7 +2,8 @@
     private _veh = _x;
     {
         if (!alive _x) then {
-            [_veh, _x] remoteExecCall ["deleteVehicleCrew", _x];
+            moveOut _x;
+            deleteVehicle _x;
         };
     } foreach crew _veh;
     if (!alive _x) then {
@@ -11,9 +12,6 @@
 } foreach vehicles;
 
 {
-    if (isNull objectParent _x) then {
-            deleteVehicle _x;
-        } else {
-            [(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-        };
+    moveOut _x;
+    deleteVehicle _x;
 } foreach allDeadMen;

--- a/addons/overthrow_main/functions/cleanup/fn_cleanup.sqf
+++ b/addons/overthrow_main/functions/cleanup/fn_cleanup.sqf
@@ -20,11 +20,8 @@ if(_vehicle isEqualType grpNull) exitWith {
 		{
 			if(!isNull objectParent _x) then {_vehs pushBackUnique (objectParent _x)};
 			if !(_x call OT_fnc_hasOwner) then {
-				if (isNull objectParent _x) then {
-					deleteVehicle _x;
-				} else {
-					[(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-				};
+				moveOut _x;
+				deleteVehicle _x;
 			};
 		}foreach(units _vehicle);
 		{
@@ -49,7 +46,8 @@ if(OT_adminMode) then {
 	}else{
 		{
 			if !(_x call OT_fnc_hasOwner) then {
-				[(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
+				moveOut _x;
+				deleteVehicle _x;
 			};
 		}foreach(crew _vehicle);
 	};

--- a/addons/overthrow_main/functions/cleanup/fn_cleanup.sqf
+++ b/addons/overthrow_main/functions/cleanup/fn_cleanup.sqf
@@ -14,7 +14,7 @@ if(_force) exitWith {
 if(_vehicle isEqualType grpNull) exitWith {
 	if(count (units _vehicle) isEqualTo 0) exitWith {deleteGroup _vehicle};
 	private _l = (units _vehicle) select 0;
-	[{!((_this#0) call OT_fnc_inSpawnDistance) || _force}, {
+	[{!((_this#0) call OT_fnc_inSpawnDistance)}, {
 		_vehs = [];
 		_this params ["_l","_vehicle"];
 		{

--- a/addons/overthrow_main/functions/events/fn_keyHandler.sqf
+++ b/addons/overthrow_main/functions/events/fn_keyHandler.sqf
@@ -255,7 +255,8 @@ if(!dialog) then {
 						sleep 2;
 						disableUserInput false;
 						cutText ["","BLACK IN",3];
-						[(objectParent _driver), _driver] remoteExec ["deleteVehicleCrew", _driver, false];
+						moveOut _driver;
+						deleteVehicle _driver;
 						deleteVehicle _veh;
 						{
 							_x allowDamage true;

--- a/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
+++ b/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
@@ -47,20 +47,14 @@ if(_dead > 150) then {
 {
 	if (_x isEqualType grpNull) then {
 		{
-			if (isNull objectParent _x) then {
-				deleteVehicle _x;
-			} else {
-				[(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-			};
+			moveOut _x;
+			deleteVehicle _x;
 		}foreach(units _x);
 		deleteGroup _x;
 	};
 	if (_x isEqualType objNull) then {
-		if (isNull objectParent _x) then {
-			deleteVehicle _x;
-		} else {
-			[(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-		};
+		moveOut _x;
+		deleteVehicle _x;
 	};
 }foreach(spawner getVariable ["_noid_",[]]);
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
@@ -70,7 +70,8 @@ if !(_frombase in _abandoned) then {
             deleteWaypoint ((waypoints _group) select 0);
         };
         _veh land "LAND";
-        waitUntil{sleep 10;(getpos _veh)#2 < 2};
+        // Sometimes helicopters land just briefly and take off again, so checking this every second
+        waitUntil{sleep 1;(getpos _veh)#2 < 2};
     };
     _veh call OT_fnc_cleanup;
     _group call OT_fnc_cleanup;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleHelicopter.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleHelicopter.sqf
@@ -74,7 +74,8 @@ if !(isNil "_from") then {
             deleteWaypoint ((waypoints _group) select 0);
         };
 		_veh land "LAND";
-		waitUntil{sleep 10;(getpos _veh)#2 < 2};
+		// Sometimes helicopters land just briefly and take off again, so checking this every second
+		waitUntil{sleep 1;(getpos _veh)#2 < 2};
     };
     _veh call OT_fnc_cleanup;
     _group call OT_fnc_cleanup;

--- a/addons/overthrow_main/functions/fn_initOverthrow.sqf
+++ b/addons/overthrow_main/functions/fn_initOverthrow.sqf
@@ -124,11 +124,8 @@ OT_tpl_checkpoint = [] call compileScript ["data\templates\NATOcheckpoint.sqf", 
 				if(_x getVariable [""OT_Looted"",false]) then {
 					private _stock = _x call OT_fnc_unitStock;
 					if((count _stock) isEqualTo 0) then {
-						if (isNull objectParent _x) then {
-							deleteVehicle _x;
-						} else {
-							[(objectParent _x), _x] remoteExec [""deleteVehicleCrew"", _unit, false];
-						};
+						moveOut _x;
+						deleteVehicle _x;
 					};
 				};
 			}forEach(alldeadmen);
@@ -137,11 +134,8 @@ OT_tpl_checkpoint = [] call compileScript ["data\templates\NATOcheckpoint.sqf", 
 				if (side group _x isEqualTo civilian && {!(isPlayer _x)} && {!(_x getVariable [""shopcheck"",false])} && { ({side _x isEqualTo civilian} count (_x nearEntities [""CAManBase"",150])) > round(150*OT_spawnCivPercentage) } ) then {
 					private _group = group _x;
 					private _unit = _x;
-					if (isNull objectParent _unit) then {
-						deleteVehicle _unit;
-					} else {
-						[(objectParent _unit), _unit] remoteExec [""deleteVehicleCrew"", _unit, false];
-					};
+					moveOut _unit;
+					deleteVehicle _unit;
 					if (count units _group < 1) then {
 						deleteGroup _group;
 					};

--- a/addons/overthrow_main/functions/virtualization/fn_despawn.sqf
+++ b/addons/overthrow_main/functions/virtualization/fn_despawn.sqf
@@ -5,11 +5,8 @@ spawner setVariable [_i,[],false];
     if(_x isEqualType grpNull) then {
         {
             if !(_x call OT_fnc_hasOwner) then {
-                if (isNull objectParent _x) then {
-                    deleteVehicle _x;
-                } else {
-                    [(objectParent _x), _x] remoteExec ["deleteVehicleCrew", _x, false];
-                };
+                moveOut _x;
+                deleteVehicle _x;
                 sleep 0.3;
             };
         }foreach(units _x);


### PR DESCRIPTION
Cleanup of old units (like a patrol after it finished and returned to base) was apparently very broken. Now it works correctly for groups, units, vehicles and their crews. This might improve performance a lot when the game has been going on for a long time.

**Bugs fixed:**
- Groups were never cleaned up
- Vehicle crew was sometimes not cleaned up
- Helicopters were sometimes not cleaned up

More info in the commit messages.