### PR TITLE
Minor fixes in loadgame

### DIFF
--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -30,7 +30,6 @@ private _cc = 0;
 				server setVariable [_subkey,_subval,true];
 			};
 		}foreach(_val);
-		_set = false;
 	};
 }foreach(_data);
 
@@ -392,7 +391,7 @@ private _hasList_buildableHouses = false;
 		_set = false;
 	};
 
-	if(_set && !(isNil "_val")) then {
+	if(_set && _key != "server" && !(isNil "_val")) then {
 		if!(toLower (_key select [0,4]) in ["ace_","cba_","bis_"]) then {
 			// server setvariable [_key,_val,true];
 			diag_log format["Dangling key value pair found: %1 - %2", _key, _val];

--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -13,7 +13,7 @@ if (isMissionProfileNamespaceLoaded) then {
 //get all server data
 "Loading persistent save" remoteExec['OT_fnc_notifyStart',0,false];
 
-if (_data isEqualType "" && {_data isEqualTo ""}) then {
+if (_data isEqualType "" && {_data isEqualTo ""}) exitWith {
 	[] remoteExec ['OT_fnc_newGame',2];
 	"No save found, starting new game" remoteExec ["hint",0,false];
 };


### PR DESCRIPTION
**Bugs fixed:**
- Pressing load game without a save was not properly starting a new game
  - Overthrow tried to simultaneously start a new game and load an empty save, which could result in wrong values for some variables.
- Error in log about dangling key when loading save