### PR TITLE
Adjust required spawning spaces for vehicles and units

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_editLoadout.sqf
+++ b/addons/overthrow_main/functions/actions/fn_editLoadout.sqf
@@ -22,7 +22,7 @@ if (_warehouse == objNull) exitWith {hint "No warehouse near by!"};
 if((count _items) isEqualTo 0) exitWith {hint "Cannot edit loadout, no items in warehouse"};
 
 //spawn a virtual dude
-private _start = (getPosATL player) findEmptyPosition [5,40,_cls];
+private _start = (getPosATL player) findEmptyPosition [5,100,_cls];
 private _civ = (group player) createUnit [_cls, _start, [],0, "NONE"];
 _civ disableAI "MOVE";
 _civ disableAI "AUTOTARGET";

--- a/addons/overthrow_main/functions/actions/fn_editPoliceLoadout.sqf
+++ b/addons/overthrow_main/functions/actions/fn_editPoliceLoadout.sqf
@@ -20,7 +20,7 @@ if (_warehouse == objNull) exitWith {hint "No warehouse near by!"};
 if((count _items) isEqualTo 0) exitWith {hint "Cannot edit loadout, no items in warehouse"};
 
 //spawn a virtual dude
-private _start = (getPosATL player) findEmptyPosition [5,40,OT_Unit_Police];
+private _start = (getPosATL player) findEmptyPosition [5,100,OT_Unit_Police];
 private _civ = (group player) createUnit [OT_Unit_Police, _start, [],0, "NONE"];
 _civ disableAI "MOVE";
 _civ disableAI "AUTOTARGET";

--- a/addons/overthrow_main/functions/factions/NATO/fn_CTRGsupport.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_CTRGsupport.sqf
@@ -44,9 +44,10 @@ sleep 0.3;
 
 //Transport
 _tgroup = creategroup blufor;
-_pos = [_pos,60,80,false,[0,0],[100,OT_NATO_Vehicle_CTRGTransport]] call SHK_pos_fnc_pos;
+private _emptypos = _pos findEmptyPosition [15,100,OT_NATO_Vehicle_CTRGTransport];
+if (count _emptypos == 0) then {_emptypos = _pos findEmptyPosition [8,100,OT_NATO_Vehicle_CTRGTransport]};
 sleep 0.3;
-_veh = createVehicle [OT_NATO_Vehicle_CTRGTransport, _pos, [], 0,""];
+_veh = createVehicle [OT_NATO_Vehicle_CTRGTransport, _emptypos, [], 0,""];
 _vehs pushback _veh;
 
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAPCInsertion.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAPCInsertion.sqf
@@ -17,10 +17,8 @@ private _veh = false;
 private _tgroup = creategroup blufor;
 
 private _dir = _frompos getDir _ao;
-private _pos = _frompos findEmptyPosition [15,100,_vehtype];
-if(count _pos == 0) then {
-	_pos = [_frompos,0,75,false,[0,0],[120,_vehtype]] call SHK_pos_fnc_pos;
-};
+private _pos = _frompos findEmptyPosition [10,100,_vehtype];
+if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 
 _veh = _vehtype createVehicle _pos;
 _veh setVariable ["garrison","HQ",false];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
@@ -36,7 +36,6 @@ if !(_frombase in _abandoned) then {
     	_x setVariable ["NOAI",true,false];
     }foreach(crew _veh);
     sleep 1;
-    private _attackpos = [_topos,[0,200]] call SHK_pos_fnc_pos;
 
     {
         _wp = _group addWaypoint [_x,50];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAirPatrol.sqf
@@ -12,8 +12,8 @@ if !(_frombase in _abandoned) then {
     if((call OT_fnc_getControlledPopulation) > 1500) then {_vehtype = selectRandom OT_NATO_Vehicles_AirSupport};
 
     private _frompos = server getVariable _frombase;
-    private _pos = _frompos findEmptyPosition [2,100,_vehtype];
-    if(isNil "_pos") exitWith {};
+    private _pos = _frompos findEmptyPosition [15,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [8,100,_vehtype]};
 
     private _group = creategroup blufor;
     private _veh = _vehtype createVehicle _pos;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOAirSupport.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOAirSupport.sqf
@@ -14,7 +14,8 @@ private _pos = false;
 }foreach(_helipads);
 
 if !(_pos isEqualType []) then {
-	_pos = [_frompos,0,120,false,[0,0],[250,_vehtype]] call SHK_pos_fnc_pos;
+	_pos = _frompos findEmptyPosition [15,100,_vehtype];
+	if (count _pos == 0) then {_pos = _frompos findEmptyPosition [8,100,_vehtype]};
 };
 
 private _group = creategroup blufor;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOConvoy.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOConvoy.sqf
@@ -20,15 +20,13 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
     if (!isNull _road) then {
         _roadscon = roadsConnectedto _road;
         if (count _roadscon isEqualTo 2) then {
-            _posVeh = (getPosATL _road) findEmptyPosition [5,25,_vehtypes select 0];
-            if(count _posVeh > 0) then {
-                _convoypos = _posVeh;
-                _dir = (_road getDir (_roadscon select 0));
-            };
+            _convoypos = getPosATL _road;
+            _dir = (_road getDir (_roadscon select 0));
         };
     };
     {
-        _pos = _convoypos;
+        _pos = _convoypos findEmptyPosition [10,100,_x];
+        if (count _pos == 0) then {_pos = _convoypos findEmptyPosition [0,100,_x]};
         _veh = createVehicle [_x, _pos, [], 0,""];
     	_veh setVariable ["garrison","HQ",false];
 
@@ -43,7 +41,7 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
     		_x setVariable ["garrison","HQ",false];
     	}foreach(crew _veh);
         _driver assignAsCommander _veh;
-        _convoyPos = _convoyPos getPos [20,_dir+180];
+        _convoypos = _convoypos getPos [20,_dir+180];
         {
             _x addCuratorEditableObjects [[_veh]];
         }foreach(allCurators);
@@ -51,7 +49,8 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
     }foreach(_vehtypes);
 
     {
-        _pos = [_convoypos,0,120,false,[0,0],[250,OT_NATO_Vehicle_HVT]] call SHK_pos_fnc_pos;
+        _pos = _convoypos findEmptyPosition [10,100,OT_NATO_Vehicle_HVT];
+        if (count _pos == 0) then {_pos = _convoypos findEmptyPosition [0,100,OT_NATO_Vehicle_HVT]};
         _veh = createVehicle [OT_NATO_Vehicle_HVT, _pos, [], 0,""];
     	_veh setVariable ["garrison","HQ",false];
 
@@ -72,7 +71,7 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
         _driver setRank "COLONEL";
         if(isNull _track) then {_track = _driver};
 
-        _convoyPos = _convoyPos getPos [20,_dir];
+        _convoypos = _convoypos getPos [20,_dir];
 
     	sleep 0.3;
         _x set [2,"CONVOY"];
@@ -84,7 +83,8 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
         private _count = 0;
         while {_count < _numsupport} do {
             _vehtype = selectRandom OT_NATO_Vehicles_GroundSupport;
-            _pos = [_convoypos,0,120,false,[0,0],[250,_vehtype]] call SHK_pos_fnc_pos;
+            _pos = _convoypos findEmptyPosition [10,100,_vehtype];
+            if (count _pos == 0) then {_pos = _convoypos findEmptyPosition [0,100,_vehtype]};
             _veh = createVehicle [_vehtype, _pos, [], 0,""];
         	_veh setVariable ["garrison","HQ",false];
         	_veh setDir (_dir);
@@ -98,7 +98,7 @@ if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
         		_x setVariable ["garrison","HQ",false];
         	}foreach(crew _veh);
             _driver assignAsCommander _veh;
-            _convoyPos = _convoyPos getPos [20,-_dir];
+            _convoypos = _convoypos getPos [20,-_dir];
             _count = _count + 1;
             sleep 0.3;
         };

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOConvoy.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOConvoy.sqf
@@ -16,7 +16,7 @@ private _track = objNull;
 
 if ([_topos,_fromregion] call OT_fnc_regionIsConnected) then {
     _convoypos = [_frompos,random 360,120] call SHK_pos_fnc_pos;
-    private _road = [_convoypos] call BIS_fnc_nearestRoad;
+    private _road = [_convoypos, 150] call BIS_fnc_nearestRoad;
     if (!isNull _road) then {
         _roadscon = roadsConnectedto _road;
         if (count _roadscon isEqualTo 2) then {

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundForces.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundForces.sqf
@@ -33,13 +33,15 @@ if(_byair) then {
 		private _on = ASLToAGL getPosASL _x nearEntities ["Air",15];
 		if((count _on) isEqualTo 0) exitWith {_pos = getPosASL _x;_dir = getDir _x};
 	}foreach(_helipads);
-};
 
-if !(_pos isEqualType []) then {
-	_pos = _frompos findEmptyPosition [15,100,_vehtype];
-	if(count _pos == 0) then {
-		_pos = [_frompos,0,75,false,[0,0],[120,_vehtype]] call SHK_pos_fnc_pos;
+	if !(_pos isEqualType []) then {
+		_pos = _frompos findEmptyPosition [15,100,_vehtype];
+		if (count _pos == 0) then {_pos = _frompos findEmptyPosition [8,100,_vehtype]};
+		_dir = (_frompos getDir _ao);
 	};
+} else {
+	_pos = _frompos findEmptyPosition [10,100,_vehtype];
+	if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 	_dir = (_frompos getDir _ao);
 };
 _pos set [2,1];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundPatrol.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundPatrol.sqf
@@ -10,7 +10,8 @@ if !(_frombase in _abandoned) then {
     if((call OT_fnc_getControlledPopulation) > 2000) then {_vehtype = selectRandom OT_NATO_Vehicles_TankSupport};
 
     private _frompos = server getVariable _frombase;
-    private _pos = _frompos findEmptyPosition [2,100,_vehtype];
+    private _pos = _frompos findEmptyPosition [10,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 
     private _group = creategroup blufor;
     private _veh = _vehtype createVehicle _pos;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundReinforcements.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundReinforcements.sqf
@@ -31,13 +31,15 @@ if(_byair) then {
 		private _on = ASLToAGL getPosASL _x nearEntities ["Air",15];
 		if((count _on) isEqualTo 0) exitWith {_pos = getPosASL _x;_dir = getDir _x};
 	}foreach(_helipads);
-};
 
-if !(_pos isEqualType []) then {
-	_pos = _frompos findEmptyPosition [15,100,_vehtype];
-	if(count _pos == 0) then {
-		_pos = [_frompos,0,75,false,[0,0],[120,_vehtype]] call SHK_pos_fnc_pos;
+	if !(_pos isEqualType []) then {
+		_pos = _frompos findEmptyPosition [15,100,_vehtype];
+		if (count _pos == 0) then {_pos = _frompos findEmptyPosition [8,100,_vehtype]};
+		_dir = (_frompos getDir _ao);
 	};
+} else {
+	_pos = _frompos findEmptyPosition [10,100,_vehtype];
+	if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 	_dir = (_frompos getDir _ao);
 };
 _pos set [2,0];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundSupport.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOGroundSupport.sqf
@@ -10,10 +10,8 @@ while {_count < _num} do {
 	private _vehtype = selectRandom OT_NATO_Vehicles_GroundSupport;
 
 	private _dir = (_frompos getDir _attackpos);
-	private _pos = _frompos findEmptyPosition [15,100,_vehtype];
-	if(count _pos == 0) then {
-		_pos = [_frompos,0,120,false,[0,0],[250,_vehtype]] call SHK_pos_fnc_pos;
-	};
+	private _pos = _frompos findEmptyPosition [10,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 
 	_veh = createVehicle [_vehtype, _pos, [], 0,""];
 	_veh setVariable ["garrison","HQ",false];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
@@ -34,7 +34,6 @@ sleep 0.5;
 _dir = (_start getDir _posTarget);
 
 if(_isAir) then {
-	_attackpos = [_posTarget,[0,150]] call SHK_pos_fnc_pos;
 
 	//Determine direction to attack from (preferrably away from water)
 	_attackdir = random 360;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
@@ -26,12 +26,12 @@ if(isNil "_close") then {
 		};
 	}foreach([OT_airportData,[],{random 100},"ASCEND"] call BIS_fnc_SortBy);
 };
-_start = [_close,50,200, 1, 0, 0, 0] call BIS_fnc_findSafePos;
-_group = [_start, WEST,  (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Support" >> OT_NATO_Group_Engineers)] call BIS_fnc_spawnGroup;
+
+_group = [_close, WEST,  (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Support" >> OT_NATO_Group_Engineers)] call BIS_fnc_spawnGroup;
 
 sleep 0.5;
 
-_dir = (_start getDir _posTarget);
+_dir = (_close getDir _posTarget);
 
 if(_isAir) then {
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
@@ -54,7 +54,8 @@ if(_isAir) then {
 	_ao = [_posTarget,[350,500],_attackdir + (random 90)] call SHK_pos_fnc_pos;
 	_tgroup = creategroup blufor;
 
-	_spawnpos = _close findEmptyPosition [5,100,OT_NATO_Vehicle_AirTransport_Small];
+	_spawnpos = _close findEmptyPosition [15,100,OT_NATO_Vehicle_AirTransport_Small];
+    if (count _spawnpos == 0) then {_spawnpos = _close findEmptyPosition [8,100,OT_NATO_Vehicle_AirTransport_Small]};
 	_veh =  OT_NATO_Vehicle_AirTransport_Small createVehicle _spawnpos;
 	_veh setDir _dir;
 	_tgroup addVehicle _veh;
@@ -121,7 +122,8 @@ if(_isAir) then {
     if (!isNull _road) then {
         _convoypos = (getpos _road);
     };
-    _spawnpos = _convoypos findEmptyPosition [5,100,OT_NATO_Vehicle_Transport_Light];
+    _spawnpos = _convoypos findEmptyPosition [10,100,OT_NATO_Vehicle_Transport_Light];
+    if (count _spawnpos == 0) then {_spawnpos = _convoypos findEmptyPosition [0,100,OT_NATO_Vehicle_Transport_Light]};
 	_veh =  OT_NATO_Vehicle_Transport_Light createVehicle _spawnpos;
 	_group addVehicle _veh;
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionDeployFOB.sqf
@@ -117,7 +117,7 @@ if(_isAir) then {
 	} forEach allCurators;
 }else{
     _convoypos = [_close,random 360,120] call SHK_pos_fnc_pos;
-    private _road = [_convoypos] call BIS_fnc_nearestRoad;
+    private _road = [_convoypos, 150] call BIS_fnc_nearestRoad;
     if (!isNull _road) then {
         _convoypos = (getpos _road);
     };

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
@@ -27,12 +27,13 @@ if(isNil "_close") then {
 		};
 	}foreach([OT_airportData,[],{random 100},"ASCEND"] call BIS_fnc_SortBy);
 };
+// Group may not be moved into a vehicle, so it also needs space to spawn
 _start = [_close,50,200, 1, 0, 0, 0] call BIS_fnc_findSafePos;
 _group = [_start, WEST, (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Infantry" >> OT_NATO_Group_Recon)] call BIS_fnc_spawnGroup;
 
 sleep 0.5;
 
-_dir = (_start getDir _posTarget);
+_dir = (_close getDir _posTarget);
 
 if(_isAir) then {
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
@@ -55,7 +55,8 @@ if(_isAir) then {
 	_ao = [_posTarget,[350,500],_attackdir + (random 90)] call SHK_pos_fnc_pos;
 	_tgroup = creategroup blufor;
 
-	_spawnpos = _close findEmptyPosition [5,100,OT_NATO_Vehicle_AirTransport_Small];
+	_spawnpos = _close findEmptyPosition [15,100,OT_NATO_Vehicle_AirTransport_Small];
+    if (count _spawnpos == 0) then {_spawnpos = _close findEmptyPosition [8,100,OT_NATO_Vehicle_AirTransport_Small]};
 	_veh =  OT_NATO_Vehicle_AirTransport_Small createVehicle _spawnpos;
 	_veh setDir _dir;
 	_tgroup addVehicle _veh;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOMissionReconDestroy.sqf
@@ -35,7 +35,6 @@ sleep 0.5;
 _dir = (_start getDir _posTarget);
 
 if(_isAir) then {
-	_attackpos = [_posTarget,[0,150]] call SHK_pos_fnc_pos;
 
 	//Determine direction to attack from (preferrably away from water)
 	_attackdir = random 360;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleHelicopter.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleHelicopter.sqf
@@ -19,7 +19,8 @@ if !(isNil "_from") then {
 
     private _frompos = _from select 0;
 
-    private _pos = _frompos findEmptyPosition [2,100,_vehtype];
+    private _pos = _frompos findEmptyPosition [15,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [8,100,_vehtype]};
 
     private _group = creategroup blufor;
     private _veh = _vehtype createVehicle _pos;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleJet.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOScrambleJet.sqf
@@ -9,7 +9,8 @@ if !(OT_NATO_HQ in _abandoned) then {
     private _vehtype = selectRandom OT_NATO_Vehicles_AirWingedSupport;
     private _frompos = OT_NATO_JetPos;
 
-    private _pos = _frompos findEmptyPosition [2,100,_vehtype];
+    private _pos = _frompos findEmptyPosition [20,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [10,100,_vehtype]};
 
     private _group = creategroup blufor;
     private _veh = _vehtype createVehicle _pos;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSeaSupport.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSeaSupport.sqf
@@ -3,6 +3,7 @@ sleep _delay;
 
 private _dir = (_frompos getDir _attackpos);
 _pos = _frompos findEmptyPosition [50,200,OT_NATO_Vehicle_Boat_Small];
+if (count _pos == 0) then {_pos = _frompos findEmptyPosition [20,200,OT_NATO_Vehicle_Boat_Small]};
 
 _group = creategroup blufor;
 _veh = createVehicle [OT_NATO_Vehicle_Boat_Small, _pos, [], 0,""];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
@@ -34,7 +34,6 @@ sleep 0.5;
 _dir = (_start getDir _posTarget);
 
 if(_isAir) then {
-	_attackpos = [_posTarget,[0,150]] call SHK_pos_fnc_pos;
 
 	//Determine direction to attack from (preferrably away from water)
 	_attackdir = random 360;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
@@ -26,12 +26,12 @@ if(isNil "_close") then {
 		};
 	}foreach([OT_airportData,[],{random 100},"ASCEND"] call BIS_fnc_SortBy);
 };
-_start = [_close,50,200, 1, 0, 0, 0] call BIS_fnc_findSafePos;
-_group = [_start, WEST,  (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Infantry" >> OT_NATO_Group_Recon)] call BIS_fnc_spawnGroup;
+
+_group = [_close, WEST,  (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO >> "Infantry" >> OT_NATO_Group_Recon)] call BIS_fnc_spawnGroup;
 
 sleep 0.5;
 
-_dir = (_start getDir _posTarget);
+_dir = (_close getDir _posTarget);
 
 if(_isAir) then {
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
@@ -122,7 +122,7 @@ if(_isAir) then {
 	} forEach allCurators;
 }else{
     _convoypos = [_close,random 360,120] call SHK_pos_fnc_pos;
-    private _road = [_convoypos] call BIS_fnc_nearestRoad;
+    private _road = [_convoypos, 150] call BIS_fnc_nearestRoad;
     if (!isNull _road) then {
         _convoypos = (getpos _road);
     };

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportRecon.sqf
@@ -54,7 +54,8 @@ if(_isAir) then {
 	_ao = [_posTarget,[350,500],_attackdir + (random 90)] call SHK_pos_fnc_pos;
 	_tgroup = creategroup blufor;
 
-	_spawnpos = _close findEmptyPosition [5,100,OT_NATO_Vehicle_CTRGTransport];
+	_spawnpos = _close findEmptyPosition [15,100,OT_NATO_Vehicle_CTRGTransport];
+	if (count _spawnpos == 0) then {_spawnpos = _close findEmptyPosition [8,100,OT_NATO_Vehicle_CTRGTransport]};
 	_veh =  OT_NATO_Vehicle_CTRGTransport createVehicle _spawnpos;
 	clearWeaponCargoGlobal _veh;
 	clearMagazineCargoGlobal _veh;
@@ -126,7 +127,8 @@ if(_isAir) then {
     if (!isNull _road) then {
         _convoypos = (getpos _road);
     };
-    _spawnpos = _convoypos findEmptyPosition [5,100,OT_NATO_Vehicle_Transport_Light];
+    _spawnpos = _convoypos findEmptyPosition [10,100,OT_NATO_Vehicle_Transport_Light];
+	if (count _spawnpos == 0) then {_spawnpos = _convoypos findEmptyPosition [0,100,OT_NATO_Vehicle_Transport_Light]};
 	_veh =  OT_NATO_Vehicle_Transport_Light createVehicle _spawnpos;
 	_group addVehicle _veh;
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportSniper.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportSniper.sqf
@@ -37,7 +37,8 @@ _ao = getpos(nearestLocation[_posTown, "Hill"]);
 if(_isHQ) then {
 	_tgroup = creategroup blufor;
 
-	_spawnpos = OT_NATO_HQPos findEmptyPosition [5,100,OT_NATO_Vehicle_AirTransport_Small];
+	_spawnpos = OT_NATO_HQPos findEmptyPosition [15,100,OT_NATO_Vehicle_AirTransport_Small];
+	if (count _spawnpos == 0) then {_spawnpos = OT_NATO_HQPos findEmptyPosition [8,100,OT_NATO_Vehicle_AirTransport_Small]};
 	_veh =  OT_NATO_Vehicle_AirTransport_Small createVehicle _spawnpos;
 	_veh setDir _dir;
 	_tgroup addVehicle _veh;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportSniper.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOSupportSniper.sqf
@@ -30,7 +30,7 @@ _group = [_start, WEST,  (configFile >> "CfgGroups" >> "West" >> OT_faction_NATO
 
 sleep 0.5;
 
-_dir = (_start getDir _posTown);
+_dir = (_close getDir _posTown);
 
 _ao = getpos(nearestLocation[_posTown, "Hill"]);
 

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOTankSupport.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOTankSupport.sqf
@@ -11,11 +11,8 @@ while {_count < _num} do {
 	private _vehtype = selectRandom OT_NATO_Vehicles_TankSupport;
 
 	private _dir = (_frompos getDir _attackpos);
-	private _pos = _frompos findEmptyPosition [15,100,_vehtype];
-	if(count _pos == 0) then {
-		_pos = [_frompos,0,120,false,[0,0],[250,_vehtype]] call SHK_pos_fnc_pos;
-	};
-
+	private _pos = _frompos findEmptyPosition [10,100,_vehtype];
+    if (count _pos == 0) then {_pos = _frompos findEmptyPosition [0,100,_vehtype]};
 
 	_veh = createVehicle [_vehtype, _pos, [], 0,""];
 	_veh setVariable ["garrison","HQ",false];

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOsendGendarmerie.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOsendGendarmerie.sqf
@@ -41,7 +41,8 @@ if(!isNil "_close") then {
 	_veh = objNull;
 
 	if(((_close distance _townPos) > 2000) && (random 100) > 50) then {
-		_spawnpos = _start findEmptyPosition [5,100,OT_NATO_Vehicle_Police];
+		_spawnpos = _close findEmptyPosition [10,100,OT_NATO_Vehicle_Police];
+		if (count _spawnpos == 0) then {_spawnpos = _close findEmptyPosition [0,100,OT_NATO_Vehicle_Police]};
 		_veh =  OT_NATO_Vehicle_Police createVehicle _spawnpos;
 		_veh setDir (random 360);
 		_group addVehicle _veh;

--- a/addons/overthrow_main/functions/factions/NATO/fn_NATOsendGendarmerie.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_NATOsendGendarmerie.sqf
@@ -34,7 +34,8 @@ if(!isNil "_close") then {
 	server setVariable [format ["garrison%1",_town],_current+4,true];
 	if !(_townPos call OT_fnc_inSpawnDistance) exitWith {};
 
-	_start = [_close,0,200, 1, 0, 0, 0] call BIS_fnc_findSafePos;
+	// Group may not be moved into a vehicle, so it also needs space to spawn
+	_start = [_close,50,200, 1, 0, 0, 0] call BIS_fnc_findSafePos;
 	_group = creategroup blufor;
 	_groups pushback _group;
 	_usecar = false;
@@ -56,21 +57,21 @@ if(!isNil "_close") then {
 	_civ setBehaviour "SAFE";
 	sleep 0.01;
 
-	_start = [_start, 0, 20, 1, 0, 0, 0] call BIS_fnc_findSafePos;
+	_start = _start findEmptyPosition [1,100,OT_NATO_Unit_Police_Heavy];
 	_civ = _group createUnit [OT_NATO_Unit_Police_Heavy, _start, [],0, "NONE"];
 
 	_police pushBack _civ;
 	[_civ,_town] call OT_fnc_initGendarm;
 	_civ setBehaviour "SAFE";
 
-	_start = [_start, 0, 20, 1, 0, 0, 0] call BIS_fnc_findSafePos;
+	_start = _start findEmptyPosition [1,100,OT_NATO_Unit_Police_Heavy];
 	_civ = _group createUnit [OT_NATO_Unit_Police_Heavy, _start, [],0, "NONE"];
 
 	_police pushBack _civ;
 	[_civ,_town] call OT_fnc_initGendarm;
 	_civ setBehaviour "SAFE";
 
-	_start = [_start, 0, 20, 1, 0, 0, 0] call BIS_fnc_findSafePos;
+	_start = _start findEmptyPosition [1,100,OT_NATO_Unit_Police_Heavy];
 	_civ = _group createUnit [OT_NATO_Unit_Police_Heavy, _start, [],0, "NONE"];
 
 	_police pushBack _civ;

--- a/addons/overthrow_main/functions/factions/fn_factionNATO.sqf
+++ b/addons/overthrow_main/functions/factions/fn_factionNATO.sqf
@@ -429,7 +429,8 @@ publicVariable "OT_nextNATOTurn";
 							_group = createGroup blufor;
 							_group deleteGroupWhenEmpty true;
 							_group setVariable ["lambs_danger_disableGroupAI", true];
-							_p = [_pos,0,0,false,[0,0],[100,OT_NATO_Vehicles_ReconDrone]] call SHK_pos_fnc_pos;
+							_p = _pos findEmptyPosition [5,100,OT_NATO_Vehicles_ReconDrone];
+							if (count _p == 0) then {_p = _pos findEmptyPosition [2,100,OT_NATO_Vehicles_ReconDrone]};
 							_drone = createVehicle [OT_NATO_Vehicles_ReconDrone, _p, [], 0,""];
 							_drone enableDynamicSimulation false;
 

--- a/addons/overthrow_main/functions/player/fn_initPlayerLocal.sqf
+++ b/addons/overthrow_main/functions/player/fn_initPlayerLocal.sqf
@@ -285,6 +285,7 @@ if (_newplayer) then {
 
 	//Free quad
 	_pos = _housepos findEmptyPosition [5,100,"C_Quadbike_01_F"];
+	if (count _pos == 0) then {_pos = _housepos findEmptyPosition [0,100,"C_Quadbike_01_F"]};
 
 	if (count _pos > 0) then {
 		_veh = "C_Quadbike_01_F" createVehicle _pos;

--- a/addons/overthrow_main/functions/player/fn_initPlayerLocal.sqf
+++ b/addons/overthrow_main/functions/player/fn_initPlayerLocal.sqf
@@ -177,7 +177,7 @@ if(isMultiplayer || _startup == "LOAD") then {
 		_xp = _x select 6;
 		if(_owner isEqualTo (getplayeruid player)) then {
 			if(_civ isEqualType []) then {
-				_pos = _civ findEmptyPosition [5,20,_type];
+				_pos = _civ findEmptyPosition [1,20,_type];
 				_civ =  group player createUnit [_type,_pos,[],0,"NONE"];
 				[_civ,getplayeruid player] call OT_fnc_setOwner;
 				_civ setVariable ["OT_xp",_xp,true];

--- a/addons/overthrow_main/functions/virtualization/spawners/fn_spawnNATOObjective.sqf
+++ b/addons/overthrow_main/functions/virtualization/spawners/fn_spawnNATOObjective.sqf
@@ -200,7 +200,7 @@ while {_count < _numNATO} do {
 
 	_count = _count + 1;
 	while {(_count < _numNATO) && (_groupcount < 8)} do {
-		_start = _start findEmptyPosition [5,50];
+		_start = _start findEmptyPosition [2,50];
 
 		_civ = _group createUnit [selectRandom (OT_NATO_Units_LevelOne + OT_NATO_Units_LevelOne + OT_NATO_Units_LevelOne + OT_NATO_Units_LevelTwo), _start, [],0, "NONE"];
 		_civ setVariable ["garrison",_name,false];
@@ -330,7 +330,7 @@ private _road = objNull;
 		_groups pushback _veh;
 		sleep 0.5;
 
-		private _pos = _vpos findEmptyPosition [5,20,OT_NATO_Unit_HVT];
+		private _pos = _vpos findEmptyPosition [2,50,OT_NATO_Unit_HVT];
 		private _civ = _group createUnit [OT_NATO_Unit_HVT, _pos, [],0, "NONE"];
 		_civ setVariable ["garrison","HQ",false];
 		_civ setVariable ["hvt",true,true];

--- a/addons/overthrow_main/functions/virtualization/spawners/fn_spawnNATOObjective.sqf
+++ b/addons/overthrow_main/functions/virtualization/spawners/fn_spawnNATOObjective.sqf
@@ -323,6 +323,7 @@ private _road = objNull;
 		_groups pushBack _group;
 		_group setVariable ["Vcm_Disable",true,true]; //stop him from running off
 		private _vpos = _posTown findEmptyPosition [10,100,OT_NATO_Vehicle_HVT];
+		if (count _vpos == 0) then {_vpos = _posTown findEmptyPosition [0,100,OT_NATO_Vehicle_HVT]};
 		//His empty APC
 		private _veh =  OT_NATO_Vehicle_HVT createVehicle _vpos;
 		_veh setpos _vpos;


### PR DESCRIPTION
This PR aims to have consistent requirements for spawning spaces of different vehicles and units.

**Before:**
Every piece of code used different spawning space requirements for vehicles and units. Sometimes it was far too little (like 0m for helicopters) which could result in explosions right at spawn. Sometimes it was a bit too much (like 5m within 20m radius for player's recruits) which could lead to units not spawning at all (see also #33).

**After:**
Space requirements are now consistent throughout the code.
5m, fallback 0m for quadbikes
10m, fallback 0m for other ground vehicles
15m, fallback 8m for helicopters
20m, fallback 10m for planes
50m, fallback 20m for boats
5m, fallback 2m for quadcopters
2m for people who are defending a location
1m for other people
0m for people that immediately get moved into a vehicle

Also the road search range for convoys was increased and the spawn range for virtual units meant for loadout editing was increased.

**Bugs fixed:**
- Sometimes a vehicle might have spawned in a space that is too small for it.
- Sometimes a unit could not be spawned in tight spaces even though there was enough space
- Convoys often spawned offroad even though there was a road next to it

**Possible caveats:**
- It could be that in rare cases a land vehicle would spawn on water where previously it did not. Those few space checks that used SHK_pos also checked if the position is on land.

More info in commit messages.