### PR TITLE
Fix bugs related to unit locality

### DIFF
--- a/addons/overthrow_main/CfgFunctions.hpp
+++ b/addons/overthrow_main/CfgFunctions.hpp
@@ -204,7 +204,6 @@ class CfgFunctions
 			class displayWarehousePic {};
 			class showMemberInfo {};
 			class showBusinessInfo {};
-			class refreshEmployees {};
 			class displayJobDetails {};
 			class displayCraftItem {};
 			class factoryRefresh {};
@@ -457,6 +456,8 @@ class CfgFunctions
 		class AI
 		{
 			file = "\overthrow_main\functions\AI";
+			class createEmployee {};
+			class deleteEmployee {};
 			class createSoldier {};
 			class getSoldier {};
 			class getSquad {};

--- a/addons/overthrow_main/CfgFunctions.hpp
+++ b/addons/overthrow_main/CfgFunctions.hpp
@@ -460,6 +460,7 @@ class CfgFunctions
 			class deleteEmployee {};
 			class createGarrisonUnit {};
 			class createGarrisonGun {};
+			class createPoliceGroup {};
 			class createSoldier {};
 			class getSoldier {};
 			class getSquad {};

--- a/addons/overthrow_main/CfgFunctions.hpp
+++ b/addons/overthrow_main/CfgFunctions.hpp
@@ -458,6 +458,8 @@ class CfgFunctions
 			file = "\overthrow_main\functions\AI";
 			class createEmployee {};
 			class deleteEmployee {};
+			class createGarrisonUnit {};
+			class createGarrisonGun {};
 			class createSoldier {};
 			class getSoldier {};
 			class getSquad {};

--- a/addons/overthrow_main/functions/AI/fn_createEmployee.sqf
+++ b/addons/overthrow_main/functions/AI/fn_createEmployee.sqf
@@ -1,0 +1,23 @@
+// This function should only be called on the server
+
+params ["_businessName"];
+
+private _group = spawner getVariable [format ["employees%1", _businessName], grpNull];
+private _pos = server getVariable _businessName;
+if (isNull _group) then {
+    // Either no player is in spawn distance or there are currently no employees on the business.
+    // Create new group using the regular spawning mechanism
+    _pos call OT_fnc_resetSpawn;
+} else {
+    // Add new member to existing group
+    _pos = [[[_pos, 50]]] call BIS_fnc_randomPos;
+
+    _civ = _group createUnit [OT_civType_worker, _pos, [], 0, "NONE"];
+
+	_civ setBehaviour "SAFE";
+    private _identity = call OT_fnc_randomLocalIdentity;
+    _identity set [1, ""]; // Retain original worker clothes
+    [_civ, _identity] call OT_fnc_applyIdentity;
+
+    _civ setVariable ["employee", _businessName, true];
+};

--- a/addons/overthrow_main/functions/AI/fn_createGarrisonGun.sqf
+++ b/addons/overthrow_main/functions/AI/fn_createGarrisonGun.sqf
@@ -1,0 +1,14 @@
+// This function should only be called on the server
+
+params ["_baseCode", "_gun"];
+
+private _group = spawner getVariable [format ["resgarrison%1", _baseCode], grpNull];
+if (isNull _group) then {
+    _group = creategroup resistance;
+    _group setVariable ["VCM_TOUGHSQUAD", true, true];
+    _group setVariable ["VCM_NORESCUE", true, true];
+    spawner setVariable [format ["resgarrison%1", _baseCode], _group, true];
+};
+
+createVehicleCrew _gun;
+crew _gun joinSilent _group;

--- a/addons/overthrow_main/functions/AI/fn_createGarrisonUnit.sqf
+++ b/addons/overthrow_main/functions/AI/fn_createGarrisonUnit.sqf
@@ -1,0 +1,26 @@
+// This function should only be called on the server
+
+params ["_baseCode", "_pos", "_soldier", "_charge"];
+
+private _group = spawner getVariable [format ["resgarrison%1", _baseCode], grpNull];
+private _doinit = false;
+if (isNull _group) then {
+    _group = creategroup resistance;
+    _group setVariable ["VCM_TOUGHSQUAD", true, true];
+    _group setVariable ["VCM_NORESCUE", true, true];
+    spawner setVariable [format ["resgarrison%1", _baseCode], _group, true];
+    _doinit = true;
+};
+
+private _unit = [_soldier, _pos, _group] call OT_fnc_createSoldier;
+
+if (_doinit) then {
+    _group call OT_fnc_initMilitaryPatrol;
+};
+if (_charge) then {
+    private _cls = _soldier # 1;
+    private _loadout = getUnitLoadout _unit;
+    private _garrison = server getVariable [format ["resgarrison%1", _baseCode],[]];
+    _garrison pushback [_cls, _loadout];
+    server setVariable [format ["resgarrison%1", _baseCode], _garrison, true];
+};

--- a/addons/overthrow_main/functions/AI/fn_createPoliceGroup.sqf
+++ b/addons/overthrow_main/functions/AI/fn_createPoliceGroup.sqf
@@ -1,0 +1,26 @@
+// This function should only be called on the server
+
+params ["_town", "_soldier", "_amount"];
+
+private _posTown = server getVariable [format ["policepos%1", _town], server getVariable _town];
+
+private _group = createGroup resistance;
+_group setVariable ["VCM_TOUGHSQUAD", true, true];
+_group setVariable ["VCM_NORESCUE", true, true];
+
+for "_i" from 1 to _amount do {
+    _pos = [[[_posTown, 35]]] call BIS_fnc_randomPos;
+
+    _unit = [_soldier, _pos, _group] call OT_fnc_createSoldier;
+    [_unit] joinSilent _group;
+    _unit setRank "SERGEANT";
+    [_unit, _town] call OT_fnc_initPolice;
+    _unit setBehaviour "SAFE";
+};
+
+_group call OT_fnc_initPolicePatrol;
+
+private _spawnid = spawner getvariable [format["townspawnid%1", _town], -1];
+private _groups = spawner getvariable [_spawnid, []];
+_groups pushBack _group;
+spawner setvariable [_spawnid, _groups, false];

--- a/addons/overthrow_main/functions/AI/fn_deleteEmployee.sqf
+++ b/addons/overthrow_main/functions/AI/fn_deleteEmployee.sqf
@@ -1,0 +1,9 @@
+// This function should only be called on the server
+
+params ["_businessName"];
+
+private _group = spawner getVariable [format ["employees%1", _businessName], grpNull];
+if (!isNull _group && count units _group > 0) then {
+    // Delete the last unit in the group
+    [units _group # -1] call OT_fnc_cleanupUnit;
+};

--- a/addons/overthrow_main/functions/UI/display/fn_refreshEmployees.sqf
+++ b/addons/overthrow_main/functions/UI/display/fn_refreshEmployees.sqf
@@ -1,7 +1,0 @@
-private _data = _this call OT_fnc_getBusinessData;
-private _pos = _data select 0;
-private _group = spawner getVariable [format["employees%1",_this],grpNull];
-{
-    [_x] call OT_fnc_cleanupUnit;
-}foreach(units _group);
-deleteGroup _group;

--- a/addons/overthrow_main/functions/actions/fn_addGarrison.sqf
+++ b/addons/overthrow_main/functions/actions/fn_addGarrison.sqf
@@ -17,15 +17,6 @@ if(
     "You cannot garrison with enemies nearby" call OT_fnc_notifyMinor;
 };
 
-private _group = spawner getVariable [format["resgarrison%1",_code],grpNull];
-private _doinit = false;
-if(isNull _group) then {
-    _group = creategroup resistance;
-    _group setVariable ["VCM_TOUGHSQUAD",true,true];
-	_group setVariable ["VCM_NORESCUE",true,true];
-    spawner setVariable [format["resgarrison%1",_code],_group,true];
-    _doinit = true;
-};
 if(_create isEqualType 1) then {
     private _sol = OT_recruitables select _create;
     _sol params ["_cls"];
@@ -40,17 +31,7 @@ if(_create isEqualType 1) then {
         [-_cost] call OT_fnc_money;
     };
 
-    private _civ = [_soldier,_pos,_group] call OT_fnc_createSoldier;
-
-    if(_doinit) then {
-        _group call OT_fnc_initMilitaryPatrol;
-    };
-    if(_charge) then {
-        _loadout = getUnitLoadout _civ;
-        _garrison = server getVariable [format["resgarrison%1",_code],[]];
-        _garrison pushback [_cls,_loadout];
-        server setVariable [format["resgarrison%1",_code],_garrison,true];
-    };
+    [_code, _pos, _soldier, _charge] remoteExec ["OT_fnc_createGarrisonUnit", 2];
 }else{
     if(_create == "HMG" || _create == "GMG") then {
         private _buildings = nearestObjects [_pos, OT_garrisonBuildings, 250];
@@ -161,10 +142,8 @@ if(_create isEqualType 1) then {
             [_gun,getplayeruid player] call OT_fnc_setOwner;
             _gun setDir _dir;
             _gun setPosATL _p;
-            createVehicleCrew _gun;
-            {
-                [_x] joinSilent _group;
-            }foreach(crew _gun);
+
+            [_code, _gun] remoteExec ["OT_fnc_createGarrisonGun", 2];
         };
     };
 };

--- a/addons/overthrow_main/functions/actions/fn_addPolice.sqf
+++ b/addons/overthrow_main/functions/actions/fn_addPolice.sqf
@@ -28,29 +28,4 @@ if(_effect isEqualTo 0) then {_effect = "None"} else {_effect = format["+%1 Stab
 ((findDisplay 9000) displayCtrl 1101) ctrlSetStructuredText parseText format["<t size=""1.5"" align=""center"">Police: %1</t>",_garrison];
 ((findDisplay 9000) displayCtrl 1104) ctrlSetStructuredText parseText format["<t size=""1.2"" align=""center"">Effects</t><br/><br/><t size=""0.8"" align=""center"">%1</t>",_effect];
 
-_count = 0;
-_range = 15;
-private _group = createGroup resistance;
-_group setVariable ["VCM_TOUGHSQUAD",true,true];
-_group setVariable ["VCM_NORESCUE",true,true];
-
-private _spawnid = spawner getvariable [format["townspawnid%1",_town],-1];
-private _groups = spawner getvariable [_spawnid,[]];
-_groups pushBack _group;
-_posTown = server getVariable [format["policepos%1",_town],server getVariable _town];
-while {_count < _amt} do {
-	_groupcount = 0;
-
-	_start = [[[_posTown,_range]]] call BIS_fnc_randomPos;
-	_pos = [[[_start,20]]] call BIS_fnc_randomPos;
-
-	_civ = [_soldier,_pos,_group] call OT_fnc_createSoldier;
-	[_civ] joinSilent _group;
-	_civ setRank "SERGEANT";
-	[_civ,_town] call OT_fnc_initPolice;
-	_civ setBehaviour "SAFE";
-
-	_count = _count + 1;
-};
-_group call OT_fnc_initPolicePatrol;
-spawner setvariable [_spawnid,_groups,false];
+[_town, _soldier, _amt] remoteExec ["OT_fnc_createPoliceGroup", 2];

--- a/addons/overthrow_main/functions/actions/fn_fireEmployee.sqf
+++ b/addons/overthrow_main/functions/actions/fn_fireEmployee.sqf
@@ -2,7 +2,9 @@ private _idx = lbCurSel 1501;
 private _name = lbData [1501,_idx];
 private _rate = server getVariable [format["%1employ",_name],0];
 _rate = _rate - 1;
-if(_rate < 0) then {_rate = 0};
+if(_rate < 0) exitWith {};
 server setVariable [format["%1employ",_name],_rate,true];
-_name remoteExec ["OT_fnc_refreshEmployees",2,false];
+
+_name remoteExec ["OT_fnc_deleteEmployee", 2];
+
 [] call OT_fnc_showBusinessInfo;

--- a/addons/overthrow_main/functions/actions/fn_hireEmployee.sqf
+++ b/addons/overthrow_main/functions/actions/fn_hireEmployee.sqf
@@ -4,5 +4,7 @@ private _rate = server getVariable [format["%1employ",_name],0];
 _rate = _rate + 1;
 if(_rate > 20) exitWith {};
 server setVariable [format["%1employ",_name],_rate,true];
-_name remoteExec ["OT_fnc_refreshEmployees",2,false];
+
+_name remoteExec ["OT_fnc_createEmployee", 2];
+
 [] call OT_fnc_showBusinessInfo;

--- a/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
+++ b/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
@@ -37,7 +37,7 @@ if !((_civ getvariable ["shop",[]]) isEqualTo []) then {_canSellDrugs = true;_ca
 if (_civ getvariable ["carshop",false]) then {_canSellDrugs = true;_canRecruit = false;_canBuyVehicles=true};
 if (_civ getvariable ["harbor",false]) then {_canSellDrugs = true;_canRecruit = false;_canBuyBoats=true};
 if (_civ getvariable ["gundealer",false]) then {_canSellDrugs = false;_canRecruit = false;_canBuyGuns=true;_canIntel=false;_canTute =true};
-if (_civ getvariable ["employee",false]) then {_canSellDrugs = false;_canRecruit = false;_canBuyGuns=false;_canIntel=false};
+if (!isNil {_civ getvariable "employee"}) then {_canSellDrugs = false;_canRecruit = false;_canBuyGuns=false;_canIntel=false};
 if (_civ getvariable ["notalk",false]) then {_canSellDrugs = false;_canRecruit = false;_canBuyGuns=false;_canIntel=false};
 if (_civ getvariable ["factionrep",false]) then {_canSellDrugs = false;_canRecruit = false;_canBuyGuns=false;_canIntel=false;_canMission=true};
 if (_civ getvariable ["crimleader",false]) then {_canSellDrugs = true;_canRecruit = false;_canBuyGuns=false;_canIntel=false;_canMission=false;_canGangJob=true};

--- a/addons/overthrow_main/functions/virtualization/spawners/fn_spawnBusinessEmployees.sqf
+++ b/addons/overthrow_main/functions/virtualization/spawners/fn_spawnBusinessEmployees.sqf
@@ -17,7 +17,7 @@ while {_count < _numCiv} do {
 	private _identity = call OT_fnc_randomLocalIdentity;
 	_identity set [1, ""]; // Retain original worker clothes
 	[_civ, _identity] call OT_fnc_applyIdentity;
-	_civ setVariable ["employee",_name];
+	_civ setVariable ["employee",_name, true];
 	_count = _count + 1;
 	sleep 0.3;
 };


### PR DESCRIPTION
Three systems allow players to create shared NPC units in overthrow: garrisons, police and business employees. These systems had bugs related to who the spawned units were local to. Now they are all local to the server.

See commit messages for more info.