### PR TITLE
Add fallback NATO faction

### DIFF
--- a/addons/overthrow_main/campaign/missions/OverthrowMpAltis.Altis/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpAltis.Altis/initVar.sqf
@@ -14,6 +14,7 @@ OT_NATOversion = 2;
 OT_CRIMversion = 1;
 
 OT_faction_NATO = "BLU_F";
+OT_fallback_faction_NATO = "BLU_T_F"; // If there were no vehicles in the first faction, take them from this faction
 OT_spawnFaction = "IND_G_F"; //This faction will have a rep in spawn town
 
 OT_flag_NATO = "Flag_NATO_F"; // Flag objects in bases

--- a/addons/overthrow_main/campaign/missions/OverthrowMpLivonia.Enoch/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpLivonia.Enoch/initVar.sqf
@@ -14,6 +14,7 @@ OT_NATOversion = 2;
 OT_CRIMversion = 1;
 
 OT_faction_NATO = "BLU_W_F";
+OT_fallback_faction_NATO = "BLU_T_F"; // If there were no vehicles in the first faction, take them from this faction
 OT_spawnFaction = "IND_F"; //This faction will have a rep in spawn town
 
 OT_flag_NATO = "Flag_NATO_F"; // Flag objects in bases

--- a/addons/overthrow_main/campaign/missions/OverthrowMpMalden.Malden/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpMalden.Malden/initVar.sqf
@@ -14,6 +14,7 @@ OT_NATOversion = 1;
 OT_CRIMversion = 1;
 
 OT_faction_NATO = "BLU_F";
+OT_fallback_faction_NATO = "BLU_T_F"; // If there were no vehicles in the first faction, take them from this faction
 OT_spawnFaction = "IND_G_F"; //This faction will have a rep in spawn town
 
 OT_flag_NATO = "Flag_NATO_F"; // Flag objects in bases

--- a/addons/overthrow_main/campaign/missions/OverthrowMpTanoa.Tanoa/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpTanoa.Tanoa/initVar.sqf
@@ -14,6 +14,7 @@ OT_NATOversion = 10;
 OT_CRIMversion = 1;
 
 OT_faction_NATO = "BLU_T_F";
+OT_fallback_faction_NATO = "BLU_F"; // If there were no vehicles in the first faction, take them from this faction
 OT_spawnFaction = "IND_F"; //This faction will have a rep in spawn town
 
 OT_flag_NATO = "Flag_NATO_F"; // Flag objects in bases

--- a/addons/overthrow_main/functions/factions/NATO/fn_initNATO.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_initNATO.sqf
@@ -144,7 +144,10 @@ if((server getVariable "StartupType") == "NEW" || (server getVariable ["NATOvers
 	if(_diff == 2) then {_numHVTs = 8};
 
 	//Find military objectives
-	_groundvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {!((_x isKindOf "Air") || (_x isKindOf "Tank") || (_x isKindOf "Ship"))}};
+	private _groundvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {!((_x isKindOf "Air") || (_x isKindOf "Tank") || (_x isKindOf "Ship"))}};
+	if (count _groundvehs == 0) then {
+		_groundvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_fallback_faction_NATO && {!((_x isKindOf "Air") || (_x isKindOf "Tank") || (_x isKindOf "Ship"))}};
+	};
 	{
 		_x params ["_pos","_name","_worth"];
 		if !(_name in _abandoned) then {
@@ -262,7 +265,10 @@ if((server getVariable "StartupType") == "NEW" || (server getVariable ["NATOvers
 		}foreach(OT_NATO_Vehicles_AirGarrison);
 
 		//Distribute some random Air vehicles
-		_airvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {_x isKindOf "Air"}};
+		private _airvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {_x isKindOf "Air"}};
+		if (count _airvehs == 0) then {
+			_airvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_fallback_faction_NATO && {_x isKindOf "Air"}};
+		};
 		{
 			_name = _x;
 			if((random 200) < (count _airvehs)) then {

--- a/addons/overthrow_main/functions/factions/NATO/fn_initNATO.sqf
+++ b/addons/overthrow_main/functions/factions/NATO/fn_initNATO.sqf
@@ -143,10 +143,8 @@ if((server getVariable "StartupType") == "NEW" || (server getVariable ["NATOvers
 	if(_diff == 0) then {_numHVTs = 4};
 	if(_diff == 2) then {_numHVTs = 8};
 
-	OT_allBLUOffensiveVehicles = (spawner getVariable format["facvehicles%1",OT_faction_NATO]) select {(getArray (configFile >> "cfgVehicles" >> _x >> "threat") # 0) > 0.5};
-
 	//Find military objectives
-	_groundvehs = OT_allBLUOffensiveVehicles select {!((_x isKindOf "Air") || (_x isKindOf "Tank") || (_x isKindOf "Ship"))};
+	_groundvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {!((_x isKindOf "Air") || (_x isKindOf "Tank") || (_x isKindOf "Ship"))}};
 	{
 		_x params ["_pos","_name","_worth"];
 		if !(_name in _abandoned) then {
@@ -264,7 +262,7 @@ if((server getVariable "StartupType") == "NEW" || (server getVariable ["NATOvers
 		}foreach(OT_NATO_Vehicles_AirGarrison);
 
 		//Distribute some random Air vehicles
-		_airvehs = OT_allBLUOffensiveVehicles select {_x isKindOf "Air"};
+		_airvehs = OT_allBLUOffensiveVehicles select {getText (configFile >> "CfgVehicles" >> _x >> "faction") == OT_faction_NATO && {_x isKindOf "Air"}};
 		{
 			_name = _x;
 			if((random 200) < (count _airvehs)) then {

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -621,7 +621,7 @@ OT_allBLURifleMagazines = [];
 				if(_cls isKindOf "LandVehicle" || _cls isKindOf "Air" || _cls isKindOf "Ship") then {
 					_vehicles pushback _cls;
 					_numblueprints = _numblueprints + 1;
-					if(_side isEqualTo 1 && (getText (_x >> "faction") == OT_faction_NATO)) then {
+					if(_side isEqualTo 1) then {
 						private _threat = getArray (_x >> "threat");
 						if(_threat # 0 > 0.5) then {
 							OT_allBLUOffensiveVehicles pushBackUnique _cls;


### PR DESCRIPTION
This PR adds a mechanism that takes vehicles from a fallback faction if they were not available in the main NATO faction. This is an important fix for Livonia, because the main woodland NATO faction has no vehicles.

I think this mechanism could also be used for some custom Overthrow missions and factions, such as a disorganized guerrilla NATO faction receiving vehicle support from the United States.

More info in the commit messages.