### PR TITLE
Enable Garrison button only when it should

### DIFF
--- a/addons/overthrow_main/functions/UI/dialogs/fn_mainMenu.sqf
+++ b/addons/overthrow_main/functions/UI/dialogs/fn_mainMenu.sqf
@@ -474,7 +474,7 @@ if (_obpos distance player < 250) then {
             };
         } else {
             private _base = player call OT_fnc_nearestBase;
-            if !(isNil "_base" && { (_base select 0) distance player < 100 }) then {
+            if (!isNil "_base" && { (_base select 0) distance player < 100 }) then {
                 ctrlEnable [1621, true];
             } else {
                 ctrlEnable [1621, false];


### PR DESCRIPTION
Fixes https://github.com/rekterakathom/Overthrow/issues/135
As @hirsja95 mentioned, the logic was flawed.
It was:
Checking if the player dont have a base 
AND
Checking if a player is close to a base.

So if the player neither has a base nor is close to one, would return False, and since the ! is outside the parenthesis, it would make the check return True, making the button visible.

Ironically, it would disable the garrisson button if the player had a base and was close to it