### PR TITLE
Make the delivery jobs actually take the weapon

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
+++ b/addons/overthrow_main/functions/actions/fn_talkToCiv.sqf
@@ -133,13 +133,25 @@ if (_delivery isNotEqualTo []) then {
                             [player, _itemcls] call {
                                 params ["_unit", "_cls"];
                                 if (_cls isKindOf ["Rifle", configFile >> "CfgWeapons"]) exitWith {
-                                    _unit removeWeapon _cls;
+                                    if (_unit hasWeapon _cls) then {
+                                        _unit removeWeapon _cls;
+                                    } else {
+                                        _unit removeItem _cls;
+                                    }
                                 };
                                 if (_cls isKindOf ["Launcher", configFile >> "CfgWeapons"]) exitWith {
-                                    _unit removeWeapon _cls;
+                                    if (_unit hasWeapon _cls) then {
+                                        _unit removeWeapon _cls;
+                                    } else {
+                                        _unit removeItem _cls;
+                                    }
                                 };
                                 if (_cls isKindOf ["Pistol", configFile >> "CfgWeapons"]) exitWith {
-                                    _unit removeWeapon _cls;
+                                    if (_unit hasWeapon _cls) then {
+                                        _unit removeWeapon _cls;
+                                    } else {
+                                        _unit removeItem _cls;
+                                    }
                                 };
                                 if (_cls isKindOf ["Binocular", configFile >> "CfgWeapons"]) exitWith {
                                     _unit removeItem _cls;


### PR DESCRIPTION
Fixes https://github.com/rekterakathom/Overthrow/issues/111 
The function removeWeapon only removes equipped weapons

This makes a check that, if it has the weapon equipped, remove it. Otherwise uses the function removeItem (Checks Uniform -> Vest -> Backpack, in that order)