### PR TITLE
Fixes string loading

### DIFF
--- a/addons/overthrow_main/functions/save/fn_saveGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_saveGame.sqf
@@ -105,9 +105,23 @@ if !(_quiet) then {
     [_x] call OT_fnc_savePlayerData;
 } forEach ([] call CBA_fnc_players);
 
-private _players = ((allVariables players_NS) select { [players_NS, _x] call _nilFilter }) apply {
-    [_x, players_NS getVariable _x];
+private _players = ((allVariables players_NS) select {
+    [players_NS, _x] call _nilFilter
+}) apply {
+    private _val = players_NS getVariable _x;
+    if (_val isEqualType []) then {
+        _val = _val select {
+            !(
+                (_x isEqualType [])
+                && { count _x > 0 }
+                && { (_x select 0) isEqualType "" }
+                && { ((_x select 0) select [0,1]) == "@" }
+            )
+        };
+    };
+    [_x, _val];
 };
+
 _data pushBack ["players", _players];
 
 private _cfgVeh = configFile >> "CfgVehicles";


### PR DESCRIPTION
Fixes https://github.com/rekterakathom/Overthrow/issues/132

Makes it so, when saving the player, checks the arrays for nested arrays, and ignores every variable that starts with "@"

Since the server also does not deal with this, I think it has no reason to save it inside the player. Also, currently its saving the values without quotes, as mentioned in the issue linked.